### PR TITLE
Ruleset switch

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -12,7 +12,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function SettingsScreen() {
   const theme = useAppTheme();
-  const { resetSpells, resetTrackers, hideOlderSpells } = use$(store);
+  const { resetSpells, resetTrackers, useNewRules } = use$(store);
   const [showThemeColors, setShowThemeColors] = useState(false);
   const [showResetWarning, setShowResetWarning] = useState(false);
   const [clearSpells, setClearSpells] = useState(false);
@@ -42,8 +42,8 @@ export default function SettingsScreen() {
         <Flex style={{ marginHorizontal: Layout.padding * 2 }}>
           <Text variant="titleLarge">App settings</Text>
           <Flex align="center" direction="row" justify="space-between" style={{ marginTop: Layout.padding }}>
-            <Text variant="titleSmall">Hide older spell version if{'\n'}a newer one exists.</Text>
-            <Switch value={hideOlderSpells} onValueChange={() => store.hideOlderSpells.set((prev) => !prev)} />
+            <Text variant="titleSmall">Use 2024 ruleset</Text>
+            <Switch value={useNewRules} onValueChange={() => store.useNewRules.set((prev) => !prev)} />
           </Flex>
         </Flex>
 

--- a/app/(tabs)/spells.tsx
+++ b/app/(tabs)/spells.tsx
@@ -17,8 +17,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 export default function SpellsScreen() {
   const [showMenu, setShowMenu] = useState(false);
   const [search, setSearch] = useState<string>('');
-  const { prepareSpell, preparedSpells, selectedClass, hideOlderSpells } = use$(store);
-  const spells = useSpells(selectedClass, hideOlderSpells);
+  const { prepareSpell, preparedSpells, selectedClass, useNewRules } = use$(store);
+  const spells = useSpells(selectedClass, useNewRules);
 
   const listRef = useRef<FlashList<Spell | string>>(null);
 

--- a/app/spell/[slug].tsx
+++ b/app/spell/[slug].tsx
@@ -2,6 +2,7 @@ import { Flex } from '@/components/Flex';
 import { useAppTheme } from '@/components/Material3ThemeProvider';
 import { View } from '@/components/Themed';
 import { Layout } from '@/constants/Layout';
+import useSpell from '@/hooks/useSpell';
 import useSpells from '@/hooks/useSpells';
 import { store } from '@/state/store';
 import { use$ } from '@legendapp/state/react';
@@ -13,12 +14,11 @@ import RenderHTML from 'react-native-render-html';
 
 export default function SpellScreen() {
   const theme = useAppTheme();
-  const { slug } = useLocalSearchParams();
-  const spells = useSpells('all', false);
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+  const spell = useSpell(slug);
 
   const { preparedSpells, prepareSpell } = use$(store);
 
-  const spell = useMemo(() => spells.find((s) => s.slug === slug), [slug, spells]);
   const isPrepared = useMemo(() => !!preparedSpells.find((s) => s.name === spell?.name), [preparedSpells, spell]);
 
   const onPrepare = useCallback(() => {

--- a/hooks/useSpell.tsx
+++ b/hooks/useSpell.tsx
@@ -1,0 +1,5 @@
+import allSpells from '@/assets/all_spells.json';
+
+export default function useSpell(slug: string) {
+  return allSpells.find((s) => s.slug === slug);
+}

--- a/hooks/useSpells.tsx
+++ b/hooks/useSpells.tsx
@@ -2,19 +2,22 @@ import allSpells from '@/assets/all_spells.json';
 import { CharacterClass } from '@/types/character-class.type';
 import { Spell } from '@/types/spell.type';
 
-export default function useSpells(characterClass: CharacterClass | 'all', hideOlderSpells: boolean = true) {
+export default function useSpells(characterClass: CharacterClass | 'all', useNewRules: boolean = true) {
   const baseList =
     characterClass === 'all' ? allSpells : allSpells.filter((s: Spell) => s.classes.includes(characterClass));
-  if (hideOlderSpells) {
-    return baseList.reduce((acc: Spell[], curr: Spell) => {
-      const index = acc.findIndex((s: Spell) => s.name === curr.name);
-      if (index !== -1) {
-        acc[index] = curr.version > acc[index].version ? curr : acc[index];
-      } else {
-        acc.push(curr);
-      }
-      return acc;
-    }, []);
+  if (!useNewRules) {
+    return baseList.filter((spell: Spell) => {
+      return spell.version !== '2024';
+    });
   }
-  return baseList;
+
+  return baseList.reduce((acc: Spell[], curr: Spell) => {
+    const index = acc.findIndex((s: Spell) => s.name === curr.name);
+    if (index !== -1) {
+      acc[index] = curr.version > acc[index].version ? curr : acc[index];
+    } else {
+      acc.push(curr);
+    }
+    return acc;
+  }, []);
 }

--- a/state/store.ts
+++ b/state/store.ts
@@ -21,6 +21,7 @@ interface Store {
   addTracker: (tracker: Tracker) => void;
   resetTrackers: () => void;
   hideOlderSpells: boolean;
+  useNewRules: boolean;
 }
 
 export const store = observable<Store>({
@@ -52,6 +53,7 @@ export const store = observable<Store>({
   sourceColor: undefined,
   useDefaultTheme: true,
   hideOlderSpells: true,
+  useNewRules: true,
 });
 
 const persistOptions = configureSynced({


### PR DESCRIPTION
The "switch to old version" switch now allow user to alternate between 2014 and 2024 ruleset. This will respectively hide all 2024 versions ("2014 ruleset") or show 2024 versions and hide 2014 versions that were replaced. 2014 spells not replaced in 2024 ruleset are still displayed.